### PR TITLE
Add minimal Oracle monitor prototype

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,5 @@
+# Oracle Monitor Backend
+
+This is a minimal Node.js backend that loads Oracle instance information from `instances.json` and exposes current metrics via `/metrics`.
+
+The backend simulates metrics using random data. Integrate the `oracledb` library and replace `generateFakeMetrics` with real queries to monitor actual databases.

--- a/backend/instances.json
+++ b/backend/instances.json
@@ -1,0 +1,14 @@
+{
+  "instances": [
+    {
+      "name": "ORCL1",
+      "connectionString": "user/password@localhost:1521/orclpdb",
+      "monitor": true
+    },
+    {
+      "name": "ORCL2",
+      "connectionString": "user/password@remote:1521/orclpdb",
+      "monitor": false
+    }
+  ]
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "oracle-monitor-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "oracledb": "^6.3.0"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import express from 'express';
+// import oracledb from 'oracledb'; // Uncomment when oracledb is available
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+const CONFIG_PATH = './instances.json';
+
+let config = JSON.parse(fs.readFileSync(CONFIG_PATH));
+let metrics = {};
+
+function generateFakeMetrics(name) {
+  return {
+    applyLag: Math.random() * 5,
+    sessions: Math.floor(Math.random() * 100),
+    sga: Math.random() * 4096,
+    pga: Math.random() * 2048,
+    processes: Math.floor(Math.random() * 500)
+  };
+}
+
+async function pollInstance(instance) {
+  if (!instance.monitor) return;
+  // Example using fake metrics instead of real queries
+  metrics[instance.name] = generateFakeMetrics(instance.name);
+}
+
+async function pollAll() {
+  for (const instance of config.instances) {
+    try {
+      await pollInstance(instance);
+    } catch (err) {
+      console.error(`Error polling ${instance.name}`, err);
+    }
+  }
+}
+
+setInterval(pollAll, 5000);
+
+app.get('/metrics', (req, res) => {
+  res.json(metrics);
+});
+
+app.listen(PORT, () => {
+  console.log(`Oracle monitor backend listening on ${PORT}`);
+});

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Oracle Monitor Frontend
+
+A simple React interface that fetches metrics from the backend every few seconds and visualizes them using `chart.js`.
+
+Run the frontend development server with:
+
+```bash
+npm install
+npm start
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "oracle-monitor-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.2"
+  },
+  "scripts": {
+    "start": "node scripts/start.js"
+  }
+}

--- a/frontend/scripts/start.js
+++ b/frontend/scripts/start.js
@@ -1,0 +1,15 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const PORT = process.env.FRONTEND_PORT || 3000;
+
+app.use(express.static(path.join(__dirname, '../src')));
+
+app.listen(PORT, () => {
+  console.log(`Frontend available on http://localhost:${PORT}`);
+});

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import Chart from 'chart.js/auto';
+
+function MetricCard({ name, data }) {
+  const canvasRef = React.useRef(null);
+
+  useEffect(() => {
+    if (!canvasRef.current || !data) return;
+    const ctx = canvasRef.current.getContext('2d');
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: ['SGA', 'PGA', 'Sessions', 'Processes', 'Apply Lag'],
+        datasets: [{
+          label: name,
+          data: [data.sga, data.pga, data.sessions, data.processes, data.applyLag],
+          backgroundColor: 'rgba(75, 192, 192, 0.5)'
+        }]
+      }
+    });
+  }, [data]);
+
+  return (
+    <div>
+      <h3>{name}</h3>
+      <canvas ref={canvasRef}></canvas>
+    </div>
+  );
+}
+
+export default function App() {
+  const [metrics, setMetrics] = useState({});
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const res = await fetch('/metrics');
+      const json = await res.json();
+      setMetrics(json);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div>
+      <h1>Oracle Monitor</h1>
+      {Object.entries(metrics).map(([name, data]) => (
+        <MetricCard key={name} name={name} data={data} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Oracle Monitor</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./index.js"></script>
+</body>
+</html>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.js';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
## Summary
- scaffold `backend` with Express server that reads instances from `instances.json`
- expose `/metrics` endpoint with fake data generator
- add `frontend` React app fetching metrics and plotting them with Chart.js

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865cec9c0788322b981d6290159a754